### PR TITLE
Initial merge and update of conda-forge recipe.

### DIFF
--- a/recipe/bld_c.bat
+++ b/recipe/bld_c.bat
@@ -1,6 +1,6 @@
 mkdir build
 cd build
-del CMakeCache.txt
+if errorlevel 1 exit 1
 
 IF not x%PKG_NAME:static=%==x%PKG_NAME% (
     set BUILD_TYPE=-DBUILD_SHARED_LIBS=OFF
@@ -8,17 +8,17 @@ IF not x%PKG_NAME:static=%==x%PKG_NAME% (
     set BUILD_TYPE=-DBUILD_SHARED_LIBS=ON
 )
 
-cmake .. ^
-      -G "NMake Makefiles" ^
-      -DCMAKE_BUILD_TYPE=Release ^
+cmake -G "Ninja" ^
+      %CMAKE_ARGS% ^
+      %BUILD_TYPE% ^
       -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
       -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
       -DCMAKE_INSTALL_LIBDIR=lib ^
       -DREPROC_TEST=ON ^
-      %BUILD_TYPE%
+      %SRC_DIR%
 
-nmake
-nmake install
+ninja install
+if errorlevel 1 exit 1
 
 IF not x%PKG_NAME:static=%==x%PKG_NAME% (
     REN %LIBRARY_PREFIX%\lib\reproc.lib reproc_static.lib

--- a/recipe/bld_cpp.bat
+++ b/recipe/bld_cpp.bat
@@ -1,6 +1,7 @@
 mkdir build-cpp
 cd build-cpp
-del CMakeCache.txt
+if errorlevel 1 exit 1
+
 
 IF not x%PKG_NAME:static=%==x%PKG_NAME% (
     set BUILD_TYPE="-DBUILD_SHARED_LIBS=OFF"
@@ -8,19 +9,22 @@ IF not x%PKG_NAME:static=%==x%PKG_NAME% (
     set BUILD_TYPE="-DBUILD_SHARED_LIBS=ON"
 )
 
-cmake .. ^
-      -G "NMake Makefiles" ^
-      -DCMAKE_BUILD_TYPE=Release ^
+cmake -G "Ninja" ^
+      %CMAKE_ARGS% ^
+      %BUILD_TYPE% ^
       -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
       -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
       -DCMAKE_INSTALL_LIBDIR=lib ^
       -DREPROC_TEST=ON ^
       -DREPROC++=ON ^
-      %BUILD_TYPE%
+      %SRC_DIR%
 
-nmake all
-nmake test
-nmake install
+ninja
+ninja test
+if errorlevel 1 exit 1
+
+ninja install
+if errorlevel 1 exit 1
 
 IF not x%PKG_NAME:static=%==x%PKG_NAME% (
     REN %LIBRARY_PREFIX%\lib\reproc++.lib reproc++_static.lib

--- a/recipe/build_c.sh
+++ b/recipe/build_c.sh
@@ -1,5 +1,8 @@
-mkdir -p build; cd build
-rm -rf CMakeCache.txt
+#!/bin/bash
+
+# Isolate the build.
+mkdir -p build
+cd build || exit 1
 
 if [[ "$PKG_NAME" == *static ]]; then
     BUILD_TYPE="-DBUILD_SHARED_LIBS=OFF"
@@ -7,15 +10,21 @@ else
     BUILD_TYPE="-DBUILD_SHARED_LIBS=ON"
 fi
 
-cmake ${CMAKE_ARGS} .. \
+
+# Generate the build files.
+cmake -G "Ninja" \
+      ${CMAKE_ARGS} \
+      ${BUILD_TYPE} \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_INSTALL_PREFIX=$PREFIX \
       -DCMAKE_INSTALL_LIBDIR=lib \
       -DREPROC_TEST=ON \
-      ${BUILD_TYPE}
+      ${SRC_DIR}
 
-make all -j${CPU_COUNT}
+
+# Build, test, and install.
+ninja || exit 1
 if [[ "$CONDA_BUILD_CROSS_COMPILATION" != "1" ]]; then
-    make test -j${CPU_COUNT}
+    ninja test || exit 1
 fi
-make install -j${CPU_COUNT}
+ninja install || exit 1

--- a/recipe/build_cpp.sh
+++ b/recipe/build_cpp.sh
@@ -1,5 +1,8 @@
-mkdir -p build-cpp; cd build-cpp
-rm -rf CMakeCache.txt
+#!/bin/bash
+
+# Isolate the build.
+mkdir -p build-cpp
+cd build-cpp || exit 1
 
 if [[ "$PKG_NAME" == *static ]]; then
     BUILD_TYPE="-DBUILD_SHARED_LIBS=OFF"
@@ -7,16 +10,23 @@ else
     BUILD_TYPE="-DBUILD_SHARED_LIBS=ON"
 fi
 
-cmake ${CMAKE_ARGS} .. \
-      -DCMAKE_BUILD_TYPE=Release \
+
+# Generate the build files.
+echo "CMAKE_ARGS: ${CMAKE_ARGS}"
+echo "SRC_DIR: ${SRC_DIR}"
+cmake -G "Ninja" \
+      ${CMAKE_ARGS} \
+      ${BUILD_TYPE} \
       -DCMAKE_INSTALL_PREFIX=$PREFIX \
       -DCMAKE_INSTALL_LIBDIR=lib \
       -DREPROC++=ON \
       -DREPROC_TEST=ON \
-      ${BUILD_TYPE}
+      ${SRC_DIR}
 
-make all -j${CPU_COUNT}
+
+# Build, test, and install.
+ninja || exit 1
 if [[ "$CONDA_BUILD_CROSS_COMPILATION" != "1" ]]; then
-    make test -j${CPU_COUNT}
+    ninja test || exit 1
 fi
-make install -j${CPU_COUNT}
+ninja install || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,7 @@
-{% set version = "14.2.3" %}
+{% set version = "14.2.4" %}
+{% set sha_hash = "55c780f7faa5c8cabd83ebbb84b68e5e0e09732de70a129f6b3c801e905415dd" %}
+{% set build_number = "0" %}
+
 
 package:
   name: reproc
@@ -6,12 +9,19 @@ package:
 
 source:
   - url: https://github.com/DaanDeMeyer/reproc/archive/v{{ version }}.tar.gz
-    sha256: ea87db7a780a81bc27bce3e6c8e5f31b831fb8a1d06c6b5c2e1c2554d1c55e00
+    sha256: {{ sha_hash }}
     patches:
       - apple_gettime.patch  # [osx]
 
 build:
-  number: 0
+  number: {{ build_number }}
+
+requirements:
+  build:
+    - {{ compiler("c") }}
+    - {{ compiler("cxx") }}
+    - cmake
+    - ninja
 
 outputs:
   - name: reproc
@@ -24,8 +34,7 @@ outputs:
       build:
         - {{ compiler("c") }}
         - cmake
-        - make   # [unix]
-        - ninja  # [win]
+        - ninja
     test:
       commands:
         - test -f ${PREFIX}/include/reproc/run.h                          # [unix]
@@ -42,18 +51,17 @@ outputs:
     script: bld_cpp.bat   # [win]
     build:
       run_exports:
-        - '{{ pin_subpackage('reproc-cpp', 'x.x') }}'
+        - {{ pin_subpackage('reproc-cpp', 'x.x') }}
     requirements:
       build:
-        - '{{ compiler("c") }}'
-        - '{{ compiler("cxx") }}'
+        - {{ compiler("c") }}
+        - {{ compiler("cxx") }}
         - cmake
-        - make   # [unix]
-        - ninja  # [win]
+        - ninja
       host:
-        - "{{ pin_subpackage('reproc', exact=True ) }}"
+        - {{ pin_subpackage('reproc', exact=True ) }}
       run:
-        - "{{ pin_subpackage('reproc', exact=True ) }}"
+        - {{ pin_subpackage('reproc', exact=True ) }}
     test:
       commands:
         - test -f ${PREFIX}/include/reproc++/reproc.hpp               # [unix]
@@ -73,12 +81,11 @@ outputs:
         - reproc
     requirements:
       build:
-        - '{{ compiler("c") }}'
+        - {{ compiler("c") }}
         - cmake
-        - make   # [unix]
-        - ninja  # [win]
+        - ninja
       host:
-        - "{{ pin_subpackage('reproc', exact=True ) }}"
+        - {{ pin_subpackage('reproc', exact=True ) }}
     test:
       commands:
         - test ! -f ${PREFIX}/include/reproc/run.h                          # [unix]
@@ -96,15 +103,14 @@ outputs:
         - reproc-cpp
     requirements:
       build:
-        - '{{ compiler("c") }}'
-        - '{{ compiler("cxx") }}'
+        - {{ compiler("c") }}
+        - {{ compiler("cxx") }}
         - cmake
-        - make   # [unix]
-        - ninja  # [win]
+        - ninja
       host:
-        - "{{ pin_subpackage('reproc', exact=True ) }}"
-        - "{{ pin_subpackage('reproc-static', exact=True ) }}"
-        - "{{ pin_subpackage('reproc-cpp', exact=True ) }}"
+        - {{ pin_subpackage('reproc', exact=True ) }}
+        - {{ pin_subpackage('reproc-static', exact=True ) }}
+        - {{ pin_subpackage('reproc-cpp', exact=True ) }}
     test:
       commands:
         - test ! -f ${PREFIX}/include/reproc++/reproc.hpp                # [unix]
@@ -117,8 +123,10 @@ about:
   home: https://github.com/DaanDeMeyer/reproc
   license_file: LICENSE
   license: MIT
+  license_family: MIT
   summary: reproc (Redirected Process) is a cross-platform C/C++ library that simplifies starting, stopping and communicating with external programs.
   dev_url: https://github.com/DaanDeMeyer/reproc
+  doc_url:
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,8 @@ source:
 
 build:
   number: {{ build_number }}
+  missing_dso_whitelist:  # [s390x]
+    - $RPATH/ld64.so.1    # [s390x]  Something is slightly amiss in the s390x build process.
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -126,7 +126,8 @@ about:
   license_family: MIT
   summary: reproc (Redirected Process) is a cross-platform C/C++ library that simplifies starting, stopping and communicating with external programs.
   dev_url: https://github.com/DaanDeMeyer/reproc
-  doc_url:
+  doc_url: https://github.com/DaanDeMeyer/reproc#reproc
+  doc_src_url: https://github.com/DaanDeMeyer/reproc
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
# Changes

Changes:
- Initial import from conda-forge.
- Update version from `14.2.3` to `14.2.4`. (Minor bugfixes.)
- Prefer ninja only (reduce maintenance costs and as a recipe fix).


# Review Information

## Upstream Changes

https://github.com/DaanDeMeyer/reproc/blob/main/CHANGELOG.md

2 memory leak bugfixes and one a non-breaking API interface improvement.

Worth taking, I believe.


## Issues

https://github.com/DaanDeMeyer/reproc/issues

Nothing that should stop this update.


## Pins and Requireds

This is a C and C++ library. The only dependency seems to be the
system's threading library. No specific version is called out.


# Clossing Comments

This is a simple import and update, the most complicated part is the
switch to ninja.