### PR TITLE
Add CMAKE_BUILD_TYPE=Release again.

### DIFF
--- a/recipe/bld_c.bat
+++ b/recipe/bld_c.bat
@@ -11,6 +11,7 @@ IF not x%PKG_NAME:static=%==x%PKG_NAME% (
 cmake -G "Ninja" ^
       %CMAKE_ARGS% ^
       %BUILD_TYPE% ^
+      -DCMAKE_BUILD_TYPE=Release ^
       -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
       -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
       -DCMAKE_INSTALL_LIBDIR=lib ^

--- a/recipe/bld_cpp.bat
+++ b/recipe/bld_cpp.bat
@@ -12,6 +12,7 @@ IF not x%PKG_NAME:static=%==x%PKG_NAME% (
 cmake -G "Ninja" ^
       %CMAKE_ARGS% ^
       %BUILD_TYPE% ^
+      -DCMAKE_BUILD_TYPE=Release ^
       -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
       -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
       -DCMAKE_INSTALL_LIBDIR=lib ^

--- a/recipe/build_cpp.sh
+++ b/recipe/build_cpp.sh
@@ -17,6 +17,7 @@ echo "SRC_DIR: ${SRC_DIR}"
 cmake -G "Ninja" \
       ${CMAKE_ARGS} \
       ${BUILD_TYPE} \
+      -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_INSTALL_PREFIX=$PREFIX \
       -DCMAKE_INSTALL_LIBDIR=lib \
       -DREPROC++=ON \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "14.2.4" %}
 {% set sha_hash = "55c780f7faa5c8cabd83ebbb84b68e5e0e09732de70a129f6b3c801e905415dd" %}
-{% set build_number = "0" %}
+{% set build_number = "1" %}
 
 
 package:


### PR DESCRIPTION
This came up when testing the conda-libmamba-solver package and @jaimergp finding out that reproc on defaults links to debug libraries. Got removed in https://github.com/AnacondaRecipes/reproc-feedstock/pull/1/files#diff-5b89c421dda1d379c6c4aedb67e907d1c0e2478f9ce79af625423c72ef76e40bL10-L11